### PR TITLE
configurar la arquitectura hexagonal básica

### DIFF
--- a/app/application/services/item_service.py
+++ b/app/application/services/item_service.py
@@ -1,0 +1,13 @@
+from typing import Optional
+from app.domain.models.item import Item
+from app.domain.ports.item_repository import ItemRepository
+
+class ItemService:
+    def __init__(self, repository: ItemRepository):
+        self.repository = repository
+
+    def get_item(self, item_id: int) -> Optional[Item]:
+        return self.repository.get(item_id)
+
+    def update_item(self, item_id: int, item: Item) -> Item:
+        return self.repository.update(item_id, item)

--- a/app/domain/models/item.py
+++ b/app/domain/models/item.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class Item:
+    id: int
+    name: str
+    price: float
+    is_offer: Optional[bool] = None

--- a/app/domain/ports/item_repository.py
+++ b/app/domain/ports/item_repository.py
@@ -1,0 +1,13 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+from app.domain.models.item import Item
+
+class ItemRepository(ABC):
+
+    @abstractmethod
+    def get(self, item_id: int) -> Optional[Item]:
+        pass
+
+    @abstractmethod
+    def update(self, item_id: int, item: Item) -> Item:
+        pass

--- a/app/infrastructure/api/item_router.py
+++ b/app/infrastructure/api/item_router.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+from typing import Optional
+
+from app.application.services.item_service import ItemService
+from app.infrastructure.persistence.local_item_repository import LocalItemRepository
+
+
+router = APIRouter()
+service = ItemService(LocalItemRepository())
+
+class ItemRequest(BaseModel):
+    name: str
+    price: float
+    is_offer: Optional[bool] = None
+
+@router.get("/items/{item_id}")
+def get_item(item_id: int):
+    item = service.get_item(item_id)
+    if item is None:
+        return {"error": "Item no encontrado"}
+    return item.__dict__
+
+@router.put("/items/{item_id}")
+def update_item(item_id: int, request: ItemRequest):
+    item = service.update_item(item_id, request.model_dump() | {"id": item_id})
+    return item.__dict__

--- a/app/infrastructure/persistence/local_item_repository.py
+++ b/app/infrastructure/persistence/local_item_repository.py
@@ -1,0 +1,16 @@
+from app.domain.models.item import Item
+from app.domain.ports.item_repository import ItemRepository
+
+class LocalItemRepository(ItemRepository):
+    def __init__(self):
+        self.items = {
+            1: Item(id=1, name="Cerveza Afor", price=5.5),
+            2: Item(id=2, name="Cerveza Capibara", price=4.5),
+        }
+
+    def get(self, item_id: int):
+        return self.items.get(item_id)
+
+    def update(self, item_id: int, item: Item):
+        self.items[item_id] = item
+        return item

--- a/app/main.py
+++ b/app/main.py
@@ -1,27 +1,16 @@
 from typing import Union
-
+from typing import List
 from fastapi import FastAPI
-from pydantic import BaseModel
+
+
+from app.domain.models.item import Item
+from app.infrastructure.persistence.local_item_repository import LocalItemRepository
 
 app = FastAPI()
+repository = LocalItemRepository()
 
 
-class Item(BaseModel):
-    name: str
-    price: float
-    is_offer: Union[bool, None] = None
+@app.get("/", response_model=List[Item])
+def get_all_items():
+    return list(repository.items.values())
 
-
-@app.get("/")
-def read_root():
-    return {"Hello": "World"}
-
-
-@app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
-    return {"item_id": item_id, "q": q}
-
-
-@app.put("/items/{item_id}")
-def update_item(item_id: int, item: Item):
-    return {"item_name": item.name, "item_id": item_id}


### PR DESCRIPTION
## Descripción
Se implementó la estructura inicial del proyecto utilizando arquitectura hexagonal.

## Cambios principales
- Separación de capas: dominio, aplicación, infraestructura.
- Repositorio local de ejemplo (`LocalItemRepository`) con dos ítems precargados.
- Se creó la base del API con FastAPI y endpoints funcionales.

## Relacionado al issue
Closes #5
